### PR TITLE
Rename compact protocol to native protocol

### DIFF
--- a/throttlecrab-server/examples/protocol_demo.rs
+++ b/throttlecrab-server/examples/protocol_demo.rs
@@ -111,8 +111,8 @@ fn test_msgpack(port: u16, protocol_name: &str) -> std::io::Result<()> {
     Ok(())
 }
 
-fn test_compact(port: u16) -> std::io::Result<()> {
-    println!("\nCompact Binary Protocol Test (port {port})");
+fn test_native(port: u16) -> std::io::Result<()> {
+    println!("\nNative Binary Protocol Test (port {port})");
     println!("{}", "-".repeat(40));
 
     let mut stream = TcpStream::connect(format!("127.0.0.1:{port}"))?;
@@ -180,7 +180,7 @@ fn main() -> std::io::Result<()> {
     println!();
     println!("Start the servers with:");
     println!("  1. cargo run --features bin -- --server --port 9090 --msgpack");
-    println!("  2. cargo run --features bin -- --server --port 9092 --compact");
+    println!("  2. cargo run --features bin -- --server --port 9092 --native");
     println!();
 
     // Test MessagePack
@@ -188,14 +188,14 @@ fn main() -> std::io::Result<()> {
         eprintln!("MessagePack protocol test failed: {e}");
     }
 
-    // Test compact binary protocol
-    if let Err(e) = test_compact(9092) {
-        eprintln!("Compact protocol test failed: {e}");
+    // Test native binary protocol
+    if let Err(e) = test_native(9092) {
+        eprintln!("Native protocol test failed: {e}");
     }
 
     println!("\nProtocol comparison summary:");
     println!("- MessagePack: Good balance of compatibility and performance");
-    println!("- Compact Binary: Best performance, custom protocol");
+    println!("- Native Binary: Best performance, custom protocol");
 
     Ok(())
 }

--- a/throttlecrab-server/src/main.rs
+++ b/throttlecrab-server/src/main.rs
@@ -10,8 +10,8 @@ use clap::Parser;
 
 use crate::actor::RateLimiterActor;
 use crate::transport::{
-    Transport, compact_protocol::CompactProtocolTransport, grpc::GrpcTransport,
-    http::HttpTransport, msgpack::MsgPackTransport,
+    Transport, grpc::GrpcTransport, http::HttpTransport, msgpack::MsgPackTransport,
+    native::NativeTransport,
 };
 use crate::types::ThrottleRequest;
 
@@ -42,9 +42,9 @@ struct Args {
     #[arg(long)]
     msgpack: bool,
 
-    /// Use compact binary protocol
+    /// Use native binary protocol
     #[arg(long)]
-    compact: bool,
+    native: bool,
 
     /// Use gRPC transport
     #[arg(long)]
@@ -85,9 +85,9 @@ async fn main() -> Result<()> {
             tracing::info!("Using HTTP transport with JSON");
             let transport = HttpTransport::new(&args.host, args.port);
             transport.start(limiter).await?;
-        } else if args.compact {
-            tracing::info!("Using compact binary protocol");
-            let transport = CompactProtocolTransport::new(&args.host, args.port);
+        } else if args.native {
+            tracing::info!("Using native binary protocol");
+            let transport = NativeTransport::new(&args.host, args.port);
             transport.start(limiter).await?;
         } else if args.msgpack {
             tracing::info!("Using MessagePack transport");

--- a/throttlecrab-server/src/transport/mod.rs
+++ b/throttlecrab-server/src/transport/mod.rs
@@ -1,8 +1,8 @@
-pub mod compact_protocol;
 pub mod grpc;
 pub mod http;
 pub mod msgpack;
 pub mod msgpack_protocol;
+pub mod native;
 
 #[cfg(test)]
 mod http_test;

--- a/throttlecrab-server/src/transport/native.rs
+++ b/throttlecrab-server/src/transport/native.rs
@@ -9,7 +9,7 @@ use std::time::UNIX_EPOCH;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
-/// Compact binary protocol for minimal overhead
+/// Native binary protocol for minimal overhead
 ///
 /// Request format (fixed size: 32 bytes + variable key length):
 /// - cmd: u8 (1 byte)
@@ -32,14 +32,14 @@ const READ_BUFFER_SIZE: usize = 256;
 const WRITE_BUFFER_SIZE: usize = 64;
 const MAX_KEY_LENGTH: usize = 255;
 
-pub struct CompactProtocolTransport {
+pub struct NativeTransport {
     host: String,
     port: u16,
 }
 
-impl CompactProtocolTransport {
+impl NativeTransport {
     pub fn new(host: &str, port: u16) -> Self {
-        CompactProtocolTransport {
+        NativeTransport {
             host: host.to_string(),
             port,
         }
@@ -153,12 +153,12 @@ impl CompactProtocolTransport {
 }
 
 #[async_trait]
-impl Transport for CompactProtocolTransport {
+impl Transport for NativeTransport {
     async fn start(self, limiter: RateLimiterHandle) -> Result<()> {
         let addr = format!("{}:{}", self.host, self.port);
         let listener = TcpListener::bind(&addr).await?;
 
-        tracing::info!("Compact protocol transport listening on {}", addr);
+        tracing::info!("Native protocol transport listening on {}", addr);
 
         let limiter = Arc::new(limiter);
 


### PR DESCRIPTION
## Summary
- Renamed the compact binary protocol to "native" protocol
- The name "native" better represents that this is throttlecrab's native/custom binary protocol

## Changes
- Renamed `src/transport/compact_protocol.rs` → `src/transport/native.rs`
- Updated struct name from `CompactProtocolTransport` to `NativeTransport`
- Changed CLI flag from `--compact` to `--native`
- Updated all imports and references in:
  - `main.rs`
  - `transport/mod.rs`
  - `examples/protocol_demo.rs`
  - `benches/protocol_comparison.rs`
- Updated comments and documentation

## Test plan
- [x] Code compiles successfully
- [x] All tests pass
- [x] Linter and formatter checks pass
- [x] Examples and benchmarks updated