### PR TITLE
Remove 'optimized' terminology from transports

### DIFF
--- a/throttlecrab-server/src/transport/msgpack.rs
+++ b/throttlecrab-server/src/transport/msgpack.rs
@@ -38,7 +38,7 @@ impl MsgPackTransport {
         // Set TCP_NODELAY for lower latency
         socket.set_nodelay(true)?;
 
-        tracing::debug!("Starting optimized connection handler");
+        tracing::debug!("Starting connection handler");
 
         loop {
             // Read length prefix (4 bytes)


### PR DESCRIPTION
## Summary
- Removed the word "optimized" from MessagePack transport debug message
- Confirmed that the native transport already has all performance optimizations

## Context
Both the MessagePack and native transports now use the same optimization techniques:
- TCP_NODELAY for low latency
- Pre-allocated and reused buffers  
- Efficient buffer management with minimal allocations
- Batched write operations where applicable

There's no need to call one "optimized" since they both implement best practices for performance.

## Test plan
- [x] Code compiles successfully
- [x] All tests pass
- [x] Linter and formatter checks pass