### PR TITLE
refactor: Remove unused log_debug method from Store trait

### DIFF
--- a/throttlecrab/benches/ahash_store.rs
+++ b/throttlecrab/benches/ahash_store.rs
@@ -84,10 +84,6 @@ impl Store for AHashStore {
         }
     }
 
-    fn log_debug(&self, _message: &str) {
-        // No-op
-    }
-
     fn set_if_not_exists_with_ttl(
         &mut self,
         key: &str,

--- a/throttlecrab/src/core/store/adaptive_cleanup.rs
+++ b/throttlecrab/src/core/store/adaptive_cleanup.rs
@@ -206,10 +206,6 @@ impl Store for AdaptiveStore {
         }
     }
 
-    fn log_debug(&self, _message: &str) {
-        // No-op in library
-    }
-
     fn set_if_not_exists_with_ttl(
         &mut self,
         key: &str,

--- a/throttlecrab/src/core/store/fast_hasher.rs
+++ b/throttlecrab/src/core/store/fast_hasher.rs
@@ -163,10 +163,6 @@ impl Store for FastHashStore {
         }
     }
 
-    fn log_debug(&self, _message: &str) {
-        // No-op in library
-    }
-
     fn set_if_not_exists_with_ttl(
         &mut self,
         key: &str,
@@ -313,10 +309,6 @@ impl Store for SimpleHashStore {
             Some((value, None)) => Ok(Some(*value)),
             _ => Ok(None),
         }
-    }
-
-    fn log_debug(&self, _message: &str) {
-        // No-op in library
     }
 
     fn set_if_not_exists_with_ttl(

--- a/throttlecrab/src/core/store/mod.rs
+++ b/throttlecrab/src/core/store/mod.rs
@@ -36,9 +36,6 @@ pub trait Store {
     /// Get value
     fn get(&self, key: &str, now: SystemTime) -> Result<Option<i64>, String>;
 
-    /// Log debug message
-    fn log_debug(&self, message: &str);
-
     /// Set if not exists with TTL
     fn set_if_not_exists_with_ttl(
         &mut self,

--- a/throttlecrab/src/core/store/periodic.rs
+++ b/throttlecrab/src/core/store/periodic.rs
@@ -130,10 +130,6 @@ impl Store for PeriodicStore {
         }
     }
 
-    fn log_debug(&self, _message: &str) {
-        // No-op in library
-    }
-
     fn set_if_not_exists_with_ttl(
         &mut self,
         key: &str,

--- a/throttlecrab/src/core/store/probabilistic.rs
+++ b/throttlecrab/src/core/store/probabilistic.rs
@@ -108,10 +108,6 @@ impl Store for ProbabilisticStore {
         }
     }
 
-    fn log_debug(&self, _message: &str) {
-        // No-op in library
-    }
-
     fn set_if_not_exists_with_ttl(
         &mut self,
         key: &str,


### PR DESCRIPTION
## Summary
- Removed the unused `log_debug` method from the `Store` trait and all implementations
- This method was never called anywhere in the codebase
- All implementations were no-ops, making this dead code

## Changes
- Removed `log_debug` method from `Store` trait definition in `mod.rs`
- Removed implementations from all store types:
  - `PeriodicStore`
  - `ProbabilisticStore`  
  - `AdaptiveStore`
  - `FastMemoryStore`
  - `FixedSizeStore` (SimpleHashStore)
  - Benchmark `AHashStore`

## Test Plan
- [x] `cargo check --all-targets` passes
- [x] `cargo fmt --all` applied
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] All existing tests pass (no functional changes)