### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.3.0] - 2025-08-01
+
+### Added
+- Comprehensive test coverage for quantity variations and token replenishment scenarios
+- Tests for edge cases including zero quantity, negative quantity, and burst limit handling
+- Tests for fractional token accumulation and time jitter handling
+
+### Fixed
+- Fixed remaining token count calculation that was always showing full capacity
+- Corrected the TAT (Theoretical Arrival Time) distance calculation in rate limiter
+- Added division by zero protection in remaining count calculation
+
+### Changed
+- Removed client timestamps from all protocols (HTTP, gRPC, Native) - server now always uses its own timestamps
+- Simplified API by removing timestamp parameters from client requests
+- Updated all documentation to reflect server-side timestamp usage
+
+### Removed
+- Client timestamp fields from all protocol definitions
+- DST-related tests that were no longer relevant with server-side timestamps
+
+## [0.2.5] - Previous version
+
+### Changed
+- Documentation updates to use HTTP as default transport

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,7 +2123,7 @@ dependencies = [
 
 [[package]]
 name = "throttlecrab"
-version = "0.2.5"
+version = "0.3.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -2131,7 +2131,7 @@ dependencies = [
 
 [[package]]
 name = "throttlecrab-integration-tests"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2153,7 +2153,7 @@ dependencies = [
 
 [[package]]
 name = "throttlecrab-server"
-version = "0.2.5"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "throttlecrab-integration-tests"
-version = "0.2.4"
+version = "0.3.0"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/throttlecrab-server/Cargo.toml
+++ b/throttlecrab-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "throttlecrab-server"
-version = "0.2.5"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 description = "A high-performance rate limiting server with multiple protocol support"
@@ -16,7 +16,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core library
-throttlecrab = { path = "../throttlecrab", version = "0.2.5", features = ["ahash"] }
+throttlecrab = { path = "../throttlecrab", version = "0.3.0", features = ["ahash"] }
 
 # Async runtime
 tokio = { workspace = true }

--- a/throttlecrab/Cargo.toml
+++ b/throttlecrab/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "throttlecrab"
-version = "0.2.5"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 description = "A high-performance GCRA (Generic Cell Rate Algorithm) rate limiter library"


### PR DESCRIPTION
## Summary

This release includes significant improvements to the rate limiter and removes client timestamps from all protocols.

## Major Changes

### Breaking Changes
- **Removed client timestamps from all protocols** (HTTP, gRPC, Native) - server now always uses its own timestamps
- Simplified API by removing timestamp parameters from client requests

### Bug Fixes
- **Fixed remaining token count calculation** that was always showing full capacity
- Corrected the TAT (Theoretical Arrival Time) distance calculation in rate limiter
- Added division by zero protection in remaining count calculation

### Improvements
- Added comprehensive test coverage for quantity variations and token replenishment scenarios
- Added tests for edge cases including zero quantity, negative quantity, and burst limit handling
- Added tests for fractional token accumulation and time jitter handling

## Changelog

See [CHANGELOG.md](CHANGELOG.md) for detailed changes.

## Migration Guide

If you were passing timestamps in your requests, simply remove them:

### Before (v0.2.x)
```json
{
  "key": "user:123",
  "max_burst": 10,
  "count_per_period": 100,
  "period": 60,
  "quantity": 1,
  "timestamp": "2024-01-01T00:00:00Z"
}
```

### After (v0.3.0)
```json
{
  "key": "user:123",
  "max_burst": 10,
  "count_per_period": 100,
  "period": 60,
  "quantity": 1
}
```

The server now always uses its own timestamp for all rate limiting decisions.

## Test Plan
- [x] All tests pass (`cargo test --all`)
- [x] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] Code is formatted (`cargo fmt --all`)