### PR TITLE
Fix broken links and outdated references in documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -40,7 +40,7 @@
 └──────────────────────────────────────────────────────────┘
 ```
 
-### 1. Actor Message Types (`src/core/mod.rs`)
+### 1. Actor Message Types (`src/types.rs`)
 
 ```rust
 pub struct ThrottleRequest {
@@ -83,7 +83,7 @@ impl RateLimiterHandle {
 }
 ```
 
-### 2. Actor Implementation (`src/core/actor.rs`)
+### 2. Actor Implementation (`src/actor.rs`)
 
 ```rust
 pub struct RateLimiterActor {
@@ -199,21 +199,31 @@ struct HttpResponse {
 ### 4. Project Structure
 
 ```
-src/
+throttlecrab-server/src/
 ├── main.rs              # Binary entry point
 ├── lib.rs               # Library exports
-├── core/
-│   ├── mod.rs           # Core traits and types
-│   ├── gcra.rs          # GCRA algorithm implementation
-│   └── storage/
-│       ├── mod.rs       # Storage trait
-│       └── memory.rs    # In-memory storage
-├── transport/
-│   ├── mod.rs           # Transport trait
-│   ├── http.rs          # HTTP/JSON
-│   ├── grpc.rs          # gRPC
-│   └── native.rs        # Native binary protocol
-└── config.rs            # Configuration structs
+├── actor.rs             # Actor-based rate limiter
+├── actor_tests.rs       # Actor tests
+├── types.rs             # Shared types and messages
+├── store.rs             # Store factory
+├── config.rs            # Configuration structs
+└── transport/
+    ├── mod.rs           # Transport trait
+    ├── http.rs          # HTTP/JSON
+    ├── grpc.rs          # gRPC
+    └── native.rs        # Native binary protocol
+
+throttlecrab/src/
+├── lib.rs               # Library exports
+└── core/
+    ├── mod.rs           # Core types and errors
+    ├── rate_limiter.rs  # GCRA implementation
+    ├── rate/            # Rate calculation utilities
+    └── store/           # Storage implementations
+        ├── mod.rs       # Store trait
+        ├── adaptive_cleanup.rs  # Adaptive store
+        ├── periodic.rs          # Periodic store
+        └── probabilistic.rs     # Probabilistic store
 ```
 
 ### 5. Dependencies
@@ -223,13 +233,18 @@ src/
 # Core
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
-# No dependencies - pure Rust implementation
 anyhow = "1"
+throttlecrab = { version = "0.3", features = ["ahash"] }
 
 # HTTP/JSON
-hyper = { version = "0.14", features = ["full"] }
+axum = "0.7"
+tower = "0.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+# gRPC
+tonic = "0.14"
+prost = "0.14"
 
 # Utilities
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Crates.io](https://img.shields.io/crates/v/throttlecrab.svg)](https://crates.io/crates/throttlecrab)
 [![Docker](https://img.shields.io/docker/v/lazureykis/throttlecrab?label=docker)](https://hub.docker.com/r/lazureykis/throttlecrab)
 [![Documentation](https://docs.rs/throttlecrab/badge.svg)](https://docs.rs/throttlecrab)
-[![License](https://img.shields.io/crates/l/throttlecrab.svg)](LICENSE-MIT)
+[![License](https://img.shields.io/crates/l/throttlecrab.svg)](LICENSE)
 
 A high-performance GCRA (Generic Cell Rate Algorithm) rate limiter for Rust. ThrottleCrab offers a pure Rust implementation with multiple storage backends and deployment options.
 
@@ -260,7 +260,7 @@ curl -X POST http://localhost:8080/throttle \
 
 ### gRPC Protocol
 
-See `proto/throttlecrab.proto` for the service definition.
+See [`throttlecrab-server/proto/throttlecrab.proto`](throttlecrab-server/proto/throttlecrab.proto) for the service definition.
 
 
 ## Contributing

--- a/throttlecrab-server/README.md
+++ b/throttlecrab-server/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/lazureykis/throttlecrab/actions/workflows/ci.yml/badge.svg)](https://github.com/lazureykis/throttlecrab/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/throttlecrab-server.svg)](https://crates.io/crates/throttlecrab-server)
 [![Documentation](https://docs.rs/throttlecrab-server/badge.svg)](https://docs.rs/throttlecrab-server)
-[![License](https://img.shields.io/crates/l/throttlecrab-server.svg)](LICENSE-MIT)
+[![License](https://img.shields.io/crates/l/throttlecrab-server.svg)](../LICENSE)
 
 A high-performance rate limiting server with multiple protocol support, built on [throttlecrab](https://crates.io/crates/throttlecrab).
 
@@ -142,7 +142,7 @@ Note: `timestamp` is optional (Unix nanoseconds). If not provided, the server us
 
 ### gRPC Protocol
 
-See `proto/throttlecrab.proto` for the service definition. Use any gRPC client library to connect.
+See [`proto/throttlecrab.proto`](proto/throttlecrab.proto) for the service definition. Use any gRPC client library to connect.
 
 ## Client Integration
 
@@ -244,8 +244,7 @@ throttlecrab-server --grpc --native \
 
 Licensed under either of:
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](../LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](../LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- MIT license ([LICENSE](../LICENSE) or http://opensource.org/licenses/MIT)
 
 at your option.
 

--- a/throttlecrab/README.md
+++ b/throttlecrab/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/lazureykis/throttlecrab/actions/workflows/ci.yml/badge.svg)](https://github.com/lazureykis/throttlecrab/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/throttlecrab.svg)](https://crates.io/crates/throttlecrab)
 [![Documentation](https://docs.rs/throttlecrab/badge.svg)](https://docs.rs/throttlecrab)
-[![License](https://img.shields.io/crates/l/throttlecrab.svg)](LICENSE-MIT)
+[![License](https://img.shields.io/crates/l/throttlecrab.svg)](../LICENSE)
 
 A high-performance GCRA (Generic Cell Rate Algorithm) rate limiter library for Rust.
 


### PR DESCRIPTION
## Summary

This PR fixes various broken links and outdated references found in the documentation files.

## Changes

### Fixed broken links:
- ✅ Fixed proto file path references: `proto/throttlecrab.proto` → `throttlecrab-server/proto/throttlecrab.proto`
- ✅ Fixed LICENSE references: `LICENSE-MIT`/`LICENSE-APACHE` → `LICENSE`
- ✅ Made proto file path a clickable link in server README

### Updated outdated content:
- ✅ Updated file structure in ARCHITECTURE.md to reflect current project structure
- ✅ Updated dependencies in ARCHITECTURE.md:
  - Changed `hyper` to `axum` for HTTP transport
  - Added missing dependencies (gRPC, throttlecrab core)
  - Removed misleading "No dependencies" comment

## Files changed:
- `README.md` - Fixed proto path and LICENSE link
- `throttlecrab/README.md` - Fixed LICENSE link
- `throttlecrab-server/README.md` - Fixed LICENSE link, proto path, removed Apache license reference
- `ARCHITECTURE.md` - Updated file structure and dependencies

## Test Plan
- [x] All links now point to existing files
- [x] All tests pass (`cargo test --all`)
- [x] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] Code is formatted (`cargo fmt --all`)