### PR TITLE
Simplify metrics collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,9 @@ throttlecrab-server
 
 Key metrics:
 - `throttlecrab_requests_total` - Total requests
-- `throttlecrab_denial_rate` - Current denial rate (0.0-1.0)
-- `throttlecrab_request_duration_bucket` - Latency histogram
+- `throttlecrab_requests_allowed` - Allowed requests
+- `throttlecrab_requests_denied` - Denied requests
+- `throttlecrab_top_denied_keys` - Top denied keys
 
 ## Protocol Reference
 

--- a/throttlecrab-server/README.md
+++ b/throttlecrab-server/README.md
@@ -164,41 +164,23 @@ Use any HTTP client, gRPC client library, or Redis client to connect to throttle
 
 #### Available Metrics
 
-##### System Metrics
+##### Core Metrics
 - `throttlecrab_uptime_seconds`: Server uptime in seconds
 - `throttlecrab_requests_total`: Total requests processed across all transports
 - `throttlecrab_requests_by_transport{transport="http|grpc|redis"}`: Requests per transport
-- `throttlecrab_connections_active{transport="http|grpc|redis"}`: Active connections per transport
-
-##### Rate Limiting Metrics
 - `throttlecrab_requests_allowed`: Total allowed requests
 - `throttlecrab_requests_denied`: Total denied requests
-- `throttlecrab_active_keys`: Number of active rate limit keys
-- `throttlecrab_store_evictions`: Total key evictions
-
-##### Performance Metrics
-- `throttlecrab_request_duration_bucket`: Request latency histogram (microseconds)
-  - Buckets: 50, 100, 250, 500, 1000, 2500, 5000, 10000, 25000, 50000, 100000
-- `throttlecrab_request_duration_sum`: Total time spent processing requests
-- `throttlecrab_request_duration_count`: Total number of requests
-
-##### Advanced Metrics (v0.4.0+)
-- `throttlecrab_denial_rate`: Current denial rate (0.0-1.0) - useful for alerting
-- `throttlecrab_avg_remaining_ratio`: Average remaining capacity ratio across all keys
-- `throttlecrab_requests_near_limit`: Number of keys using >90% of their capacity
-- `throttlecrab_total_capacity_used`: Sum of all tokens consumed
-- `throttlecrab_total_capacity_available`: Sum of all token limits
-- `throttlecrab_key_distribution_bucket`: Distribution of request counts per key
-  - Buckets: 1, 10, 100, 1000, 10000, 100000, 1000000 requests
+- `throttlecrab_requests_errors`: Total internal errors
+- `throttlecrab_top_denied_keys{key="...",rank="1-100"}`: Top denied keys by count
 
 #### Example Prometheus Queries
 
 ```promql
-# Monitor P99 latency
-histogram_quantile(0.99, rate(throttlecrab_request_duration_bucket[5m]))
+# Monitor denial rate
+rate(throttlecrab_requests_denied[5m]) / rate(throttlecrab_requests_total[5m])
 
-# Alert on high denial rate
-throttlecrab_denial_rate > 0.1
+# Alert on high error rate
+rate(throttlecrab_requests_errors[5m]) > 0.01
 ```
 
 ### Store Types

--- a/throttlecrab-server/src/metrics.rs
+++ b/throttlecrab-server/src/metrics.rs
@@ -5,8 +5,8 @@
 
 use std::collections::HashMap;
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
 
 /// Maximum length allowed for rate limit keys
 const MAX_KEY_LENGTH: usize = 256;
@@ -84,51 +84,13 @@ pub struct Metrics {
     pub requests_denied: AtomicU64,
     pub requests_errors: AtomicU64,
 
-    /// Active connections by transport
-    pub http_connections: AtomicUsize,
-    pub grpc_connections: AtomicUsize,
-    pub redis_connections: AtomicUsize,
-
-    /// Request latency buckets (in microseconds)
-    pub latency_under_1ms: AtomicU64,
-    pub latency_under_10ms: AtomicU64,
-    pub latency_under_100ms: AtomicU64,
-    pub latency_under_1s: AtomicU64,
-    pub latency_over_1s: AtomicU64,
-
-    /// Histogram support
-    pub latency_sum_micros: AtomicU64,
-
-    /// Store metrics
-    pub active_keys: AtomicUsize,
-    pub store_evictions: AtomicU64,
-
-    /// Advanced metrics
+    /// Top denied keys tracking
     pub(crate) top_denied_keys: Mutex<TopDeniedKeys>,
-    pub denial_window_start: AtomicU64,
-    pub requests_in_window: AtomicU64,
-    pub denials_in_window: AtomicU64,
-    pub requests_per_minute: Mutex<[AtomicU64; 60]>,
-    pub current_minute: AtomicUsize,
-    pub last_cleanup_duration_micros: AtomicU64,
-    pub last_cleanup_evicted: AtomicU64,
 }
 
 impl Metrics {
     /// Create a new metrics instance
     pub fn new() -> Self {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-
-        // Initialize requests_per_minute array
-        let mut rpm_array = Vec::with_capacity(60);
-        for _ in 0..60 {
-            rpm_array.push(AtomicU64::new(0));
-        }
-        let rpm_array: [AtomicU64; 60] = rpm_array.try_into().unwrap();
-
         Self {
             start_time: Instant::now(),
             total_requests: AtomicU64::new(0),
@@ -138,82 +100,14 @@ impl Metrics {
             requests_allowed: AtomicU64::new(0),
             requests_denied: AtomicU64::new(0),
             requests_errors: AtomicU64::new(0),
-            http_connections: AtomicUsize::new(0),
-            grpc_connections: AtomicUsize::new(0),
-            redis_connections: AtomicUsize::new(0),
-            latency_under_1ms: AtomicU64::new(0),
-            latency_under_10ms: AtomicU64::new(0),
-            latency_under_100ms: AtomicU64::new(0),
-            latency_under_1s: AtomicU64::new(0),
-            latency_over_1s: AtomicU64::new(0),
-            latency_sum_micros: AtomicU64::new(0),
-            active_keys: AtomicUsize::new(0),
-            store_evictions: AtomicU64::new(0),
             top_denied_keys: Mutex::new(TopDeniedKeys::new(100)),
-            denial_window_start: AtomicU64::new(now),
-            requests_in_window: AtomicU64::new(0),
-            denials_in_window: AtomicU64::new(0),
-            requests_per_minute: Mutex::new(rpm_array),
-            current_minute: AtomicUsize::new((now / 60) as usize),
-            last_cleanup_duration_micros: AtomicU64::new(0),
-            last_cleanup_evicted: AtomicU64::new(0),
         }
     }
 
-    /// Record a request and its latency with key information
-    pub fn record_request_with_key(
-        &self,
-        transport: Transport,
-        latency_us: u64,
-        allowed: bool,
-        key: &str,
-    ) {
+    /// Record a request with key information
+    pub fn record_request_with_key(&self, transport: Transport, allowed: bool, key: &str) {
         // Update all the metrics that don't need the key
-        self.record_request(transport, latency_us, allowed);
-
-        // Update advanced metrics
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-
-        // Update denial window metrics
-        let window_start = self.denial_window_start.load(Ordering::Relaxed);
-        if now - window_start > 300 {
-            // Reset 5-minute window
-            self.denial_window_start.store(now, Ordering::Relaxed);
-            self.requests_in_window.store(1, Ordering::Relaxed);
-            self.denials_in_window
-                .store(if allowed { 0 } else { 1 }, Ordering::Relaxed);
-        } else {
-            self.requests_in_window.fetch_add(1, Ordering::Relaxed);
-            if !allowed {
-                self.denials_in_window.fetch_add(1, Ordering::Relaxed);
-            }
-        }
-
-        // Update requests per minute
-        let current_minute = (now / 60) as usize;
-        let last_minute = self.current_minute.load(Ordering::Relaxed);
-
-        if current_minute != last_minute {
-            // Clear old minutes if we've jumped ahead
-            if let Ok(rpm) = self.requests_per_minute.lock() {
-                let diff = current_minute.wrapping_sub(last_minute);
-                if diff > 0 && diff < 60 {
-                    for i in 1..=diff.min(60) {
-                        let idx = (last_minute + i) % 60;
-                        rpm[idx].store(0, Ordering::Relaxed);
-                    }
-                }
-            }
-            self.current_minute.store(current_minute, Ordering::Relaxed);
-        }
-
-        if let Ok(rpm) = self.requests_per_minute.lock() {
-            let idx = current_minute % 60;
-            rpm[idx].fetch_add(1, Ordering::Relaxed);
-        }
+        self.record_request(transport, allowed);
 
         // Update top denied keys if request was denied
         if !allowed {
@@ -223,8 +117,8 @@ impl Metrics {
         }
     }
 
-    /// Record a request and its latency
-    pub fn record_request(&self, transport: Transport, latency_us: u64, allowed: bool) {
+    /// Record a request
+    pub fn record_request(&self, transport: Transport, allowed: bool) {
         self.total_requests.fetch_add(1, Ordering::Relaxed);
 
         // Record transport-specific counter
@@ -240,55 +134,10 @@ impl Metrics {
         } else {
             self.requests_denied.fetch_add(1, Ordering::Relaxed);
         }
-
-        // Record latency bucket
-        match latency_us {
-            0..=999 => self.latency_under_1ms.fetch_add(1, Ordering::Relaxed),
-            1000..=9999 => self.latency_under_10ms.fetch_add(1, Ordering::Relaxed),
-            10000..=99999 => self.latency_under_100ms.fetch_add(1, Ordering::Relaxed),
-            100000..=999999 => self.latency_under_1s.fetch_add(1, Ordering::Relaxed),
-            _ => self.latency_over_1s.fetch_add(1, Ordering::Relaxed),
-        };
-
-        // Update histogram metrics
-        self.latency_sum_micros
-            .fetch_add(latency_us, Ordering::Relaxed);
-    }
-
-    /// Update active connection count
-    #[allow(dead_code)]
-    pub fn connection_opened(&self, transport: Transport) {
-        match transport {
-            Transport::Http => self.http_connections.fetch_add(1, Ordering::Relaxed),
-            Transport::Grpc => self.grpc_connections.fetch_add(1, Ordering::Relaxed),
-            Transport::Redis => self.redis_connections.fetch_add(1, Ordering::Relaxed),
-        };
-    }
-
-    /// Update active connection count
-    #[allow(dead_code)]
-    pub fn connection_closed(&self, transport: Transport) {
-        match transport {
-            Transport::Http => self.http_connections.fetch_sub(1, Ordering::Relaxed),
-            Transport::Grpc => self.grpc_connections.fetch_sub(1, Ordering::Relaxed),
-            Transport::Redis => self.redis_connections.fetch_sub(1, Ordering::Relaxed),
-        };
-    }
-
-    /// Update active keys count
-    #[allow(dead_code)]
-    pub fn update_active_keys(&self, count: usize) {
-        self.active_keys.store(count, Ordering::Relaxed);
-    }
-
-    /// Record a store eviction
-    #[allow(dead_code)]
-    pub fn record_eviction(&self) {
-        self.store_evictions.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Record an internal error
-    pub fn record_error(&self, transport: Transport, latency_us: u64) {
+    pub fn record_error(&self, transport: Transport) {
         self.total_requests.fetch_add(1, Ordering::Relaxed);
         self.requests_errors.fetch_add(1, Ordering::Relaxed);
 
@@ -298,49 +147,6 @@ impl Metrics {
             Transport::Grpc => self.grpc_requests.fetch_add(1, Ordering::Relaxed),
             Transport::Redis => self.redis_requests.fetch_add(1, Ordering::Relaxed),
         };
-
-        // Record latency bucket even for errors
-        match latency_us {
-            0..=999 => self.latency_under_1ms.fetch_add(1, Ordering::Relaxed),
-            1000..=9999 => self.latency_under_10ms.fetch_add(1, Ordering::Relaxed),
-            10000..=99999 => self.latency_under_100ms.fetch_add(1, Ordering::Relaxed),
-            100000..=999999 => self.latency_under_1s.fetch_add(1, Ordering::Relaxed),
-            _ => self.latency_over_1s.fetch_add(1, Ordering::Relaxed),
-        };
-
-        // Update histogram metrics for errors too
-        self.latency_sum_micros
-            .fetch_add(latency_us, Ordering::Relaxed);
-    }
-
-    /// Record store cleanup metrics
-    #[allow(dead_code)]
-    pub fn record_cleanup(&self, duration: Duration, evicted_count: usize) {
-        self.last_cleanup_duration_micros
-            .store(duration.as_micros() as u64, Ordering::Relaxed);
-        self.last_cleanup_evicted
-            .store(evicted_count as u64, Ordering::Relaxed);
-    }
-
-    /// Get current requests per minute
-    pub fn get_requests_per_minute(&self) -> u64 {
-        if let Ok(rpm) = self.requests_per_minute.lock() {
-            rpm.iter().map(|a| a.load(Ordering::Relaxed)).sum()
-        } else {
-            0
-        }
-    }
-
-    /// Get denial rate percentage
-    pub fn get_denial_rate_percent(&self) -> f64 {
-        let requests = self.requests_in_window.load(Ordering::Relaxed);
-        let denials = self.denials_in_window.load(Ordering::Relaxed);
-
-        if requests == 0 {
-            0.0
-        } else {
-            (denials as f64 / requests as f64) * 100.0
-        }
     }
 
     /// Get server uptime in seconds
@@ -370,8 +176,8 @@ impl Metrics {
 
     /// Export metrics in Prometheus text format
     pub fn export_prometheus(&self) -> String {
-        // Estimate size: ~50 chars per metric line, ~30 metrics = ~1500 chars
-        let mut output = String::with_capacity(1500);
+        // Estimate size: ~50 chars per metric line, ~7 metrics = ~350 chars
+        let mut output = String::with_capacity(500);
 
         // Add header
         output.push_str("# HELP throttlecrab_uptime_seconds Time since server start in seconds\n");
@@ -429,88 +235,6 @@ impl Metrics {
             self.requests_errors.load(Ordering::Relaxed)
         ));
 
-        // Active connections
-        output.push_str(
-            "# HELP throttlecrab_connections_active Current active connections by transport\n",
-        );
-        output.push_str("# TYPE throttlecrab_connections_active gauge\n");
-        output.push_str(&format!(
-            "throttlecrab_connections_active{{transport=\"http\"}} {}\n",
-            self.http_connections.load(Ordering::Relaxed)
-        ));
-        output.push_str(&format!(
-            "throttlecrab_connections_active{{transport=\"grpc\"}} {}\n",
-            self.grpc_connections.load(Ordering::Relaxed)
-        ));
-        output.push_str(&format!(
-            "throttlecrab_connections_active{{transport=\"redis\"}} {}\n\n",
-            self.redis_connections.load(Ordering::Relaxed)
-        ));
-
-        // Latency distribution
-        output
-            .push_str("# HELP throttlecrab_request_duration_bucket Request latency distribution\n");
-        output.push_str("# TYPE throttlecrab_request_duration_bucket histogram\n");
-        output.push_str(&format!(
-            "throttlecrab_request_duration_bucket{{le=\"0.001\"}} {}\n",
-            self.latency_under_1ms.load(Ordering::Relaxed)
-        ));
-        output.push_str(&format!(
-            "throttlecrab_request_duration_bucket{{le=\"0.01\"}} {}\n",
-            self.latency_under_1ms.load(Ordering::Relaxed)
-                + self.latency_under_10ms.load(Ordering::Relaxed)
-        ));
-        output.push_str(&format!(
-            "throttlecrab_request_duration_bucket{{le=\"0.1\"}} {}\n",
-            self.latency_under_1ms.load(Ordering::Relaxed)
-                + self.latency_under_10ms.load(Ordering::Relaxed)
-                + self.latency_under_100ms.load(Ordering::Relaxed)
-        ));
-        output.push_str(&format!(
-            "throttlecrab_request_duration_bucket{{le=\"1\"}} {}\n",
-            self.latency_under_1ms.load(Ordering::Relaxed)
-                + self.latency_under_10ms.load(Ordering::Relaxed)
-                + self.latency_under_100ms.load(Ordering::Relaxed)
-                + self.latency_under_1s.load(Ordering::Relaxed)
-        ));
-        // Calculate total for +Inf bucket (sum of all buckets)
-        let total_in_buckets = self.latency_under_1ms.load(Ordering::Relaxed)
-            + self.latency_under_10ms.load(Ordering::Relaxed)
-            + self.latency_under_100ms.load(Ordering::Relaxed)
-            + self.latency_under_1s.load(Ordering::Relaxed)
-            + self.latency_over_1s.load(Ordering::Relaxed);
-
-        output.push_str(&format!(
-            "throttlecrab_request_duration_bucket{{le=\"+Inf\"}} {total_in_buckets}\n"
-        ));
-
-        // Add sum and count for proper histogram
-        let latency_sum_seconds =
-            self.latency_sum_micros.load(Ordering::Relaxed) as f64 / 1_000_000.0;
-        output.push_str(&format!(
-            "throttlecrab_request_duration_sum {latency_sum_seconds:.6}\n"
-        ));
-        output.push_str(&format!(
-            "throttlecrab_request_duration_count {total_in_buckets}\n\n"
-        ));
-
-        // Store metrics
-        output.push_str("# HELP throttlecrab_active_keys Number of active rate limit keys\n");
-        output.push_str("# TYPE throttlecrab_active_keys gauge\n");
-        output.push_str(&format!(
-            "throttlecrab_active_keys {}\n\n",
-            self.active_keys.load(Ordering::Relaxed)
-        ));
-
-        output.push_str("# HELP throttlecrab_store_evictions Total number of key evictions\n");
-        output.push_str("# TYPE throttlecrab_store_evictions counter\n");
-        output.push_str(&format!(
-            "throttlecrab_store_evictions {}\n\n",
-            self.store_evictions.load(Ordering::Relaxed)
-        ));
-
-        // Advanced metrics
-
         // Top denied keys
         output.push_str("# HELP throttlecrab_top_denied_keys Top keys by denial count\n");
         output.push_str("# TYPE throttlecrab_top_denied_keys gauge\n");
@@ -524,53 +248,6 @@ impl Metrics {
                 ));
             }
         }
-        output.push('\n');
-
-        // Denial rate
-        output.push_str("# HELP throttlecrab_denial_rate_percent Percentage of requests denied in last 5 minutes\n");
-        output.push_str("# TYPE throttlecrab_denial_rate_percent gauge\n");
-        output.push_str(&format!(
-            "throttlecrab_denial_rate_percent {:.2}\n\n",
-            self.get_denial_rate_percent()
-        ));
-
-        // Requests per minute
-        output.push_str(
-            "# HELP throttlecrab_requests_per_minute Total requests in the last minute\n",
-        );
-        output.push_str("# TYPE throttlecrab_requests_per_minute gauge\n");
-        output.push_str(&format!(
-            "throttlecrab_requests_per_minute {}\n\n",
-            self.get_requests_per_minute()
-        ));
-
-        // Store performance metrics
-        output.push_str(
-            "# HELP throttlecrab_cleanup_duration_seconds Duration of last cleanup operation\n",
-        );
-        output.push_str("# TYPE throttlecrab_cleanup_duration_seconds gauge\n");
-        let cleanup_duration_secs =
-            self.last_cleanup_duration_micros.load(Ordering::Relaxed) as f64 / 1_000_000.0;
-        output.push_str(&format!(
-            "throttlecrab_cleanup_duration_seconds {cleanup_duration_secs:.6}\n\n"
-        ));
-
-        output.push_str("# HELP throttlecrab_last_cleanup_evicted_keys Number of keys evicted in last cleanup\n");
-        output.push_str("# TYPE throttlecrab_last_cleanup_evicted_keys gauge\n");
-        output.push_str(&format!(
-            "throttlecrab_last_cleanup_evicted_keys {}\n\n",
-            self.last_cleanup_evicted.load(Ordering::Relaxed)
-        ));
-
-        // Estimated memory usage (rough approximation: 100 bytes per key)
-        let estimated_memory = self.active_keys.load(Ordering::Relaxed) * 100;
-        output.push_str(
-            "# HELP throttlecrab_estimated_memory_bytes Estimated memory usage in bytes\n",
-        );
-        output.push_str("# TYPE throttlecrab_estimated_memory_bytes gauge\n");
-        output.push_str(&format!(
-            "throttlecrab_estimated_memory_bytes {estimated_memory}\n"
-        ));
 
         output
     }
@@ -609,59 +286,21 @@ mod tests {
         let metrics = Metrics::new();
 
         // Record an allowed HTTP request
-        metrics.record_request(Transport::Http, 500, true);
+        metrics.record_request(Transport::Http, true);
 
         assert_eq!(metrics.total_requests.load(Ordering::Relaxed), 1);
         assert_eq!(metrics.http_requests.load(Ordering::Relaxed), 1);
         assert_eq!(metrics.requests_allowed.load(Ordering::Relaxed), 1);
         assert_eq!(metrics.requests_denied.load(Ordering::Relaxed), 0);
-        assert_eq!(metrics.latency_under_1ms.load(Ordering::Relaxed), 1);
 
         // Record a denied gRPC request
-        metrics.record_request(Transport::Grpc, 50000, false);
+        metrics.record_request(Transport::Grpc, false);
 
         assert_eq!(metrics.total_requests.load(Ordering::Relaxed), 2);
         assert_eq!(metrics.grpc_requests.load(Ordering::Relaxed), 1);
         assert_eq!(metrics.http_requests.load(Ordering::Relaxed), 1);
         assert_eq!(metrics.requests_allowed.load(Ordering::Relaxed), 1);
         assert_eq!(metrics.requests_denied.load(Ordering::Relaxed), 1);
-        assert_eq!(metrics.latency_under_100ms.load(Ordering::Relaxed), 1);
-    }
-
-    #[test]
-    fn test_connection_tracking() {
-        let metrics = Metrics::new();
-
-        // Open connections
-        metrics.connection_opened(Transport::Http);
-        metrics.connection_opened(Transport::Http);
-        metrics.connection_opened(Transport::Grpc);
-
-        assert_eq!(metrics.http_connections.load(Ordering::Relaxed), 2);
-        assert_eq!(metrics.grpc_connections.load(Ordering::Relaxed), 1);
-
-        // Close one HTTP connection
-        metrics.connection_closed(Transport::Http);
-
-        assert_eq!(metrics.http_connections.load(Ordering::Relaxed), 1);
-    }
-
-    #[test]
-    fn test_latency_buckets() {
-        let metrics = Metrics::new();
-
-        // Test different latency ranges
-        metrics.record_request(Transport::Http, 500, true); // < 1ms
-        metrics.record_request(Transport::Http, 5000, true); // < 10ms
-        metrics.record_request(Transport::Http, 50000, true); // < 100ms
-        metrics.record_request(Transport::Http, 500000, true); // < 1s
-        metrics.record_request(Transport::Http, 5000000, true); // > 1s
-
-        assert_eq!(metrics.latency_under_1ms.load(Ordering::Relaxed), 1);
-        assert_eq!(metrics.latency_under_10ms.load(Ordering::Relaxed), 1);
-        assert_eq!(metrics.latency_under_100ms.load(Ordering::Relaxed), 1);
-        assert_eq!(metrics.latency_under_1s.load(Ordering::Relaxed), 1);
-        assert_eq!(metrics.latency_over_1s.load(Ordering::Relaxed), 1);
     }
 
     #[test]
@@ -669,9 +308,8 @@ mod tests {
         let metrics = Metrics::new();
 
         // Add some test data
-        metrics.record_request(Transport::Http, 500, true);
-        metrics.record_request(Transport::Grpc, 1500, false);
-        metrics.connection_opened(Transport::Http);
+        metrics.record_request(Transport::Http, true);
+        metrics.record_request(Transport::Grpc, false);
 
         let output = metrics.export_prometheus();
 
@@ -682,7 +320,6 @@ mod tests {
         assert!(output.contains("throttlecrab_requests_denied 1"));
         assert!(output.contains("throttlecrab_requests_by_transport{transport=\"http\"} 1"));
         assert!(output.contains("throttlecrab_requests_by_transport{transport=\"grpc\"} 1"));
-        assert!(output.contains("throttlecrab_connections_active{transport=\"http\"} 1"));
     }
 
     #[test]
@@ -690,11 +327,11 @@ mod tests {
         let metrics = Metrics::new();
 
         // Record various requests
-        metrics.record_request(Transport::Http, 500, true); // allowed
-        metrics.record_request(Transport::Http, 1500, false); // denied
-        metrics.record_request(Transport::Grpc, 2500, true); // allowed
-        metrics.record_request(Transport::Grpc, 50000, false); // denied
-        metrics.record_error(Transport::Http, 10000); // error
+        metrics.record_request(Transport::Http, true); // allowed
+        metrics.record_request(Transport::Http, false); // denied
+        metrics.record_request(Transport::Grpc, true); // allowed
+        metrics.record_request(Transport::Grpc, false); // denied
+        metrics.record_error(Transport::Http); // error
 
         // Verify total requests
         assert_eq!(metrics.total_requests.load(Ordering::Relaxed), 5);
@@ -710,22 +347,9 @@ mod tests {
             + metrics.requests_errors.load(Ordering::Relaxed);
         assert_eq!(decision_sum, 5);
 
-        // Verify histogram buckets sum correctly
-        let bucket_sum = metrics.latency_under_1ms.load(Ordering::Relaxed)
-            + metrics.latency_under_10ms.load(Ordering::Relaxed)
-            + metrics.latency_under_100ms.load(Ordering::Relaxed)
-            + metrics.latency_under_1s.load(Ordering::Relaxed)
-            + metrics.latency_over_1s.load(Ordering::Relaxed);
-        assert_eq!(bucket_sum, 5);
-
         // Verify specific counts
         assert_eq!(metrics.requests_allowed.load(Ordering::Relaxed), 2);
         assert_eq!(metrics.requests_denied.load(Ordering::Relaxed), 2);
         assert_eq!(metrics.requests_errors.load(Ordering::Relaxed), 1);
-
-        // Verify histogram export consistency
-        let output = metrics.export_prometheus();
-        assert!(output.contains("throttlecrab_request_duration_bucket{le=\"+Inf\"} 5"));
-        assert!(output.contains("throttlecrab_request_duration_count 5"));
     }
 }

--- a/throttlecrab-server/tests/metrics_test.rs
+++ b/throttlecrab-server/tests/metrics_test.rs
@@ -2,58 +2,39 @@ use std::sync::Arc;
 use throttlecrab_server::metrics::{Metrics, Transport};
 
 #[test]
-fn test_advanced_metrics() {
+fn test_top_denied_keys() {
     let metrics = Arc::new(Metrics::new());
 
     // Test top denied keys
-    metrics.record_request_with_key(Transport::Http, 1000, false, "user:123");
-    metrics.record_request_with_key(Transport::Http, 1000, false, "user:123");
-    metrics.record_request_with_key(Transport::Http, 1000, false, "user:456");
-    metrics.record_request_with_key(Transport::Http, 1000, true, "user:789");
-
-    // Test requests per minute
-    for _ in 0..10 {
-        metrics.record_request_with_key(Transport::Http, 1000, true, "test");
-    }
+    metrics.record_request_with_key(Transport::Http, false, "user:123");
+    metrics.record_request_with_key(Transport::Http, false, "user:123");
+    metrics.record_request_with_key(Transport::Http, false, "user:456");
+    metrics.record_request_with_key(Transport::Http, true, "user:789");
 
     let prometheus = metrics.export_prometheus();
 
     // Verify top denied keys are exported
     assert!(prometheus.contains("throttlecrab_top_denied_keys"));
     assert!(prometheus.contains("user:123"));
-
-    // Verify denial rate
-    assert!(prometheus.contains("throttlecrab_denial_rate_percent"));
-
-    // Verify requests per minute
-    assert!(prometheus.contains("throttlecrab_requests_per_minute"));
-
-    // Extract the requests per minute value
-    let rpm = metrics.get_requests_per_minute();
-    assert_eq!(rpm, 14); // 4 (3 denied + 1 allowed from top denied test) + 10 allowed
-
-    // Verify cleanup metrics
-    assert!(prometheus.contains("throttlecrab_cleanup_duration_seconds"));
-    assert!(prometheus.contains("throttlecrab_last_cleanup_evicted_keys"));
-
-    // Verify estimated memory
-    assert!(prometheus.contains("throttlecrab_estimated_memory_bytes"));
+    assert!(prometheus.contains("user:456"));
+    // user:789 should not appear as it was allowed
+    assert!(!prometheus.contains("user:789"));
 }
 
 #[test]
-fn test_denial_rate_calculation() {
+fn test_request_counting() {
     let metrics = Arc::new(Metrics::new());
 
     // 10 requests, 3 denied
     for i in 0..10 {
         let allowed = i >= 3;
-        metrics.record_request_with_key(Transport::Http, 1000, allowed, "test");
+        metrics.record_request_with_key(Transport::Http, allowed, "test");
     }
 
-    let rate = metrics.get_denial_rate_percent();
-    assert!((rate - 30.0).abs() < 0.01); // 30% denial rate
+    let prometheus = metrics.export_prometheus();
 
-    // Test requests per minute
-    let rpm = metrics.get_requests_per_minute();
-    assert_eq!(rpm, 10);
+    // Verify request counts
+    assert!(prometheus.contains("throttlecrab_requests_total 10"));
+    assert!(prometheus.contains("throttlecrab_requests_allowed 7"));
+    assert!(prometheus.contains("throttlecrab_requests_denied 3"));
 }


### PR DESCRIPTION
## Summary

This PR simplifies the metrics collection system by removing non-working and unnecessary metrics, keeping only the essential ones that are actually useful and functional.

## Changes Made

### Removed Metrics:
- **Connection tracking metrics** (`throttlecrab_connections_active`) - not working
- **Request duration/latency metrics** (`throttlecrab_request_duration_bucket`) - all queries are fast, not needed
- **Store-related metrics** (`active_keys`, `store_evictions`) - showing 0, not working properly
- **Advanced metrics**:
  - `throttlecrab_denial_rate_percent` - not needed
  - `throttlecrab_requests_per_minute` - not needed  
  - `throttlecrab_cleanup_duration_seconds` - not needed
  - `throttlecrab_last_cleanup_evicted_keys` - not needed
- **Memory estimation metric** (`throttlecrab_estimated_memory_bytes`) - showing 0, not working

### Kept Metrics:
- `throttlecrab_uptime_seconds` - Server uptime
- `throttlecrab_requests_total` - Total request count
- `throttlecrab_requests_by_transport` - Requests by transport type (HTTP/gRPC/Redis)
- `throttlecrab_requests_allowed` - Allowed requests count
- `throttlecrab_requests_denied` - Denied requests count
- `throttlecrab_requests_errors` - Error count
- `throttlecrab_top_denied_keys` - Top denied keys tracking

## Benefits

- Cleaner, simpler metrics system
- Only tracks what's actually working and needed
- Reduced overhead from unused metric tracking
- Easier to understand and maintain

## Test Results

All tests pass:
- `cargo test --all` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo fmt --all` ✅