### PR TITLE
fix: add graceful shutdown signal handling for Docker containers

### DIFF
--- a/throttlecrab-server/src/main.rs
+++ b/throttlecrab-server/src/main.rs
@@ -37,8 +37,8 @@ mod actor_tests;
 
 use anyhow::Result;
 use std::sync::Arc;
-use tokio::task::JoinSet;
 use tokio::signal;
+use tokio::task::JoinSet;
 
 use crate::config::Config;
 use crate::metrics::Metrics;

--- a/throttlecrab-server/src/main.rs
+++ b/throttlecrab-server/src/main.rs
@@ -38,6 +38,7 @@ mod actor_tests;
 use anyhow::Result;
 use std::sync::Arc;
 use tokio::task::JoinSet;
+use tokio::signal;
 
 use crate::config::Config;
 use crate::metrics::Metrics;
@@ -114,19 +115,57 @@ async fn main() -> Result<()> {
         });
     }
 
-    // Wait for all transport tasks to complete (they run indefinitely)
-    while let Some(result) = transport_tasks.join_next().await {
-        match result {
-            Ok(Ok(())) => {
-                tracing::info!("Transport task completed successfully");
+    // Wait for shutdown signal or transport task completion
+    let shutdown_signal = async {
+        let ctrl_c = signal::ctrl_c();
+
+        #[cfg(unix)]
+        let sigterm = async {
+            signal::unix::signal(signal::unix::SignalKind::terminate())
+                .expect("Failed to install SIGTERM handler")
+                .recv()
+                .await;
+        };
+
+        #[cfg(not(unix))]
+        let sigterm = std::future::pending::<()>();
+
+        tokio::select! {
+            _ = ctrl_c => {
+                tracing::info!("Received SIGINT (Ctrl+C), initiating graceful shutdown...");
             }
-            Ok(Err(e)) => {
-                tracing::error!("Transport task failed: {}", e);
-                return Err(e);
+            _ = sigterm => {
+                tracing::info!("Received SIGTERM, initiating graceful shutdown...");
             }
-            Err(e) => {
-                tracing::error!("Transport task panicked: {}", e);
-                return Err(anyhow::anyhow!("Transport task panicked"));
+        }
+    };
+
+    tokio::select! {
+        _ = shutdown_signal => {
+            tracing::info!("Shutdown signal received, stopping all transports...");
+            transport_tasks.abort_all();
+
+            // Give tasks a moment to clean up
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+            tracing::info!("ThrottleCrab server shutdown complete");
+            return Ok(());
+        }
+        result = transport_tasks.join_next() => {
+            if let Some(result) = result {
+                match result {
+                    Ok(Ok(())) => {
+                        tracing::info!("Transport task completed successfully");
+                    }
+                    Ok(Err(e)) => {
+                        tracing::error!("Transport task failed: {}", e);
+                        return Err(e);
+                    }
+                    Err(e) => {
+                        tracing::error!("Transport task panicked: {}", e);
+                        return Err(anyhow::anyhow!("Transport task panicked"));
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Fixes Docker containers not responding to `docker stop` commands
- Adds proper SIGINT and SIGTERM signal handling for graceful shutdown
- Replaces infinite task loop with `tokio::select!` for concurrent signal/task handling

## Problem
Docker containers were ignoring SIGTERM signals and hanging for 10 seconds before being force-killed with SIGKILL. This happened because:
- Application ran as PID 1 without proper signal handling
- Main loop ran indefinitely with no shutdown mechanism
- No graceful cleanup of transport tasks

## Solution
- Added `tokio::signal` handlers for SIGINT (Ctrl+C) and SIGTERM
- Implemented graceful shutdown logic that aborts all transport tasks
- Added proper logging during shutdown process
- 100ms cleanup delay to ensure clean shutdown

## Test plan
- [x] All tests pass (`cargo test --all`)
- [x] No clippy warnings (`cargo clippy --all-targets --all-features -- -D warnings`) 
- [x] Manual testing shows graceful shutdown works with Ctrl+C
- [x] Docker containers now respond immediately to `docker stop`

## Result
- `docker stop` now works immediately without timeout
- Proper graceful shutdown of all transport protocols
- Clean application exit with appropriate logging