### PR TITLE
chore(deny): allow CC0-1.0 license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -20,6 +20,7 @@ allow = [
     "Zlib",
     "BSL-1.0",
     "Unicode-3.0",
+    "CC0-1.0",
 ]
 
 [sources]


### PR DESCRIPTION
## Summary
A new transitive dependency `tiny-keccak` (pulled in via `config` → `rust-ini` → `ordered-multimap` → `dlv-list` → `const-random` → `const-random-macro`) is licensed under **CC0-1.0**, which was missing from the `deny.toml` allow list and caused `cargo deny check licenses` to fail.

CC0-1.0 is a public-domain dedication. The FSF classifies it as Free/Libre, and it imposes fewer obligations than MIT or Apache-2.0, so adding it is safe.

## Test plan
- [x] `cargo deny check` reports `advisories ok, bans ok, licenses ok, sources ok`