### PR TITLE
Release: publish image to GHCR and deploy to k3s

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      packages: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -323,11 +324,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Docker Hub
+      - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v6
@@ -337,8 +339,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/throttlecrab:${{ steps.version.outputs.version }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/throttlecrab:latest
+            ghcr.io/lazureykis/throttlecrab:${{ steps.version.outputs.version }}
+            ghcr.io/lazureykis/throttlecrab:latest
           labels: |
             org.opencontainers.image.description=ThrottleCrab rate limiting server
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
@@ -346,6 +348,18 @@ jobs:
           provenance: false
           sbom: false
           outputs: type=registry,progress=plain
+
+      - name: Deploy to production k3s
+        env:
+          KUBECONFIG_DATA: ${{ secrets.KUBECONFIG }}
+        run: |
+          curl -sSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -sSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x /usr/local/bin/kubectl
+          mkdir -p "$HOME/.kube"
+          printf '%s' "$KUBECONFIG_DATA" > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+          kubectl set image deployment/throttlecrab throttlecrab=ghcr.io/lazureykis/throttlecrab:${{ steps.version.outputs.version }} -n production
+          kubectl rollout status deployment/throttlecrab -n production --timeout=5m
 
       - name: Cleanup on failure
         if: failure()


### PR DESCRIPTION
Migrates the release pipeline's container image off Docker Hub to GHCR and adds a k3s deploy.

## Changes
- Docker build/push now targets **`ghcr.io/lazureykis/throttlecrab:<version>`** and `:latest` (personal namespace; pushed with the repo's `GITHUB_TOKEN` + `packages: write` — no Docker Hub creds).
- New **Deploy to production k3s** step: `kubectl set image deployment/throttlecrab` in namespace `production`, then waits for rollout.
- Kubeconfig is written from an env var via `printf` (never echoed) to avoid exposure in logs.

## Notes / prerequisites
- `KUBECONFIG` repo secret has been added.
- Runs on `ubuntu-latest` (no self-hosted runner on this repo); deploy reaches the internet-exposed k3s API on :6443.
- **Security note:** this is a *public* repo and the `KUBECONFIG` secret holds a cluster-admin credential. The release workflow is `workflow_dispatch`-only, so fork PRs cannot access it, but consider a scoped ServiceAccount token or making the repo private.
- After first release, update the infra repo's `throttlecrab-deployment.yaml` image to `ghcr.io/lazureykis/throttlecrab`. The old `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets are now unused by this workflow.