### PR TITLE
Backfill CHANGELOG for 0.4.5-0.4.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+Releases are cut by the `Release` workflow (see [RELEASING.md](RELEASING.md)),
+which generates per-release notes on the
+[GitHub releases page](https://github.com/lazureykis/throttlecrab/releases)
+from the commit log. This file is the curated view: it records changes that
+affect users of the `throttlecrab` and `throttlecrab-server` crates or the
+published Docker image, and omits dependency bumps and CI-only changes.
+
+## [0.4.5] - [0.4.39] - 2025-08 – 2026-07
+
+Backfilled from git history. Most releases in this range were dependency
+updates and release-automation work with no user-facing change; the entries
+below are everything that altered runtime behavior or the published image.
+
+### Changed
+
+- **The server now binds to `0.0.0.0` by default instead of `127.0.0.1`** (0.4.30).
+  This applies to the HTTP, gRPC, and Redis listeners, and means a default
+  configuration is reachable from outside the host. Set `THROTTLECRAB_HTTP_HOST`
+  (or the corresponding per-protocol variable / CLI flag) back to `127.0.0.1` to
+  restore loopback-only binding.
+- The Docker image enables the Redis protocol by default (0.4.24).
+- The Docker image is built `FROM scratch` around a static musl binary (0.4.25).
+- Release images are published to `ghcr.io/lazureykis/throttlecrab` (0.4.38).
+
+### Added
+
+- Graceful shutdown on `SIGTERM`/`SIGINT` so containers stop cleanly rather than
+  being killed after the runtime's grace period (0.4.31).
+
 ## [0.4.4] - 2025-08-23
 
 ### Added

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,6 +7,10 @@ version it calculates.
 
 ## How to release
 
+0. If anything in the release changes runtime behavior, the public API, or the
+   Docker image, add an entry to [CHANGELOG.md](CHANGELOG.md) first — the
+   workflow generates GitHub release notes from commits, but not that file.
+   Dependency bumps and CI-only changes don't need one.
 1. Make sure `main` is green and everything you want in the release is merged.
 2. Go to [Actions → Release](https://github.com/lazureykis/throttlecrab/actions/workflows/release.yml)
    and click **Run workflow** (or `gh workflow run release.yml --ref main`).


### PR DESCRIPTION
`CHANGELOG.md` stopped at 0.4.4 (August 2025) while 35 releases shipped, so it claimed to document "all notable changes" across a gap that included a change to the default bind address.

Rather than fabricate an entry per version — most were dependency bumps and release-automation work — I filtered the range to commits that touched `throttlecrab/src`, `throttlecrab-server/src`, or the `Dockerfile`, and grouped the four real changes under one range heading:

- **0.4.30 — default bind address `127.0.0.1` → `0.0.0.0`.** The most consequential of the four: a default config now listens on all interfaces. Documented with the env var to set it back.
- 0.4.31 — graceful `SIGTERM`/`SIGINT` shutdown
- 0.4.24 — Redis protocol on by default in the Docker image
- 0.4.25 — Docker image rebuilt `FROM scratch`
- 0.4.38 — images published to GHCR

The header now scopes the file to user-facing changes and points at the GitHub releases page for per-release commit-level notes, so the two aren't expected to duplicate each other. `RELEASING.md` gains a step 0 reminding you to add an entry when a release changes behavior — that omission is why it rotted.

Every claim is derived from git history; versions were resolved with `git tag --contains`.